### PR TITLE
Add commas to sources list in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,8 +5,8 @@ description = 'LAPACK header'
 subprojects = ['mir-core']
 
 sources_list = [
-    'lapack/lapack'
-    'lapack/package'
+    'lapack/lapack',
+    'lapack/package',
 ]
 
 sources = []


### PR DESCRIPTION
@9il I'm getting an error about the sources list for this project when trying to build docs. I think adding commas will fix it, but open to suggestions.
https://app.circleci.com/pipelines/github/libmir/mir-stat/250/workflows/f918ba09-38a6-43bb-806e-51c334eb74a7/jobs/285

![image](https://github.com/libmir/lapack/assets/12736202/cecca747-942e-41e3-810f-46014eb16b6e)
